### PR TITLE
chore(output): rename built to dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .vscode
-built
+dist
 node_modules
 .nyc_output/
 coverage/

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "url": "https://github.com/catalyticlabs/catalytic-sdk-node/issues",
     "email": "sdk@catalytic.com"
   },
-  "main": "built/index.js",
-  "types": "built/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
-    "built/**/*"
+    "dist/**/*"
   ],
   "scripts": {
     "autorest": "autorest",
@@ -62,7 +62,7 @@
   "keywords": [],
   "license": "SEE LICENSE IN license.txt",
   "eslintIgnore": [
-    "built/*",
+    "dist/*",
     "src/internal/*"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "declaration": true,
         "esModuleInterop": true,
-        "outDir": "./built"
+        "outDir": "./dist"
     },
     "module": "commonjs",
     "lib": ["es2018"],


### PR DESCRIPTION
`dist` is the common output directory name, based on what I've seen