### PR TITLE
fix: export client type reference

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,2 @@
 export * from './src/entities';
-import _CatalyticClient from './src/CatalyticClient';
-
-export const CatalyticClient = _CatalyticClient;
-
-export default CatalyticClient;
+export { default as CatalyticClient } from './src/CatalyticClient';


### PR DESCRIPTION
The default export of the SDK is `typeof CatalyticClient`, which
limits users to declare a variable as a `CatalyticClient` instance.

For example, the following would produce a TypeScript error prior to
this update:

``` typescript
import CatalyticClient from '@catalytic/sdk';

const client: CatalyticClient = new CatalyticClient();
```