### PR TITLE
fix: browser compilation support for parcel and browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,5 +71,8 @@
   "eslintIgnore": [
     "dist/*",
     "src/internal/*"
-  ]
+  ],
+  "browser": {
+    "open": false
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
-import open = require('open');
+import { existsSync, readFileSync, readdirSync, unlinkSync, writeFileSync, mkdirSync } from 'fs';
+// eslint-disable-next-line import/default
+import open from 'open';
 
 import { InvalidTeamNameError } from './errors';
 
@@ -43,3 +45,19 @@ const UUID_REGEX = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12
 export function isUUID(value: string): boolean {
     return UUID_REGEX.test(value.trim().toLowerCase());
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function wrapNative<T extends Function>(fn: T, defaultReturn: any = undefined): T {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return function(...args: any[]) {
+        return !!fn ? fn(...args) : defaultReturn;
+    } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
+// Native wrappers Node FS functions for browser environments
+export const exists = wrapNative(existsSync, false);
+export const mkdir = wrapNative(mkdirSync);
+export const readFile = wrapNative(readFileSync, '');
+export const readdir = wrapNative(readdirSync, []);
+export const unlink = wrapNative(unlinkSync);
+export const writeFile = wrapNative(writeFileSync);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
     "compilerOptions": {
-        "declaration": true,
-        "esModuleInterop": true,
-        "outDir": "./dist",
-        "target": "ES5"
+      "declaration": true,
+      "esModuleInterop": true,
+      "lib": ["dom", "es2015"],
+      "module": "commonjs",
+      "outDir": "./dist",
+      "target": "es5"
     },
-    "module": "commonjs",
-    "lib": ["es2018"],
     "include": ["./src/**/*", "./index.ts"]
 }


### PR DESCRIPTION
- Replaces `fs.*` calls with wrapped call to prevent browser compilers
  from attempting to access static file references

- Adds `browser.open = false` to `package.json` file to prevent
  browser compiler from attempting to access Linux proc files

- Corrects `tsconfig.json` compiler options